### PR TITLE
Issue: Wrong distance calculating #374

### DIFF
--- a/tms/models/tms_route.py
+++ b/tms/models/tms_route.py
@@ -108,14 +108,17 @@ class TmsRoute(models.Model):
                 result = json.loads(requests.get(url, params=params).content)
                 distance = duration = 0.0
                 if result['status'] == 'OK':
-                    if rec.route_place_ids:
+                    if rec.route_place_ids or (rec.departure_id and
+                                               rec.arrival_id):
+                        pos = 0
                         for row in result['rows']:
                             distance += (
-                                row['elements'][0]['distance']
+                                row['elements'][pos]['distance']
                                    ['value'] / 1000.0)
                             duration += (
-                                row['elements'][0]['duration']
+                                row['elements'][pos]['duration']
                                    ['value'] / 3600.0)
+                            pos += 1
                 self.distance = distance
                 self.travel_time = duration
             except Exception:


### PR DESCRIPTION
# Issue: Wrong distance calculating #374
## Distance and travel time are not calculating, while using only departure and arrival places.

Wrong expression in **if** in **tms/models/tms_route.py** on 111 row.
```
                    if rec.route_place_ids:
```
It does not include *departure_id* and *arrival_id* and distance isn`t calculating.

fixed in [Fork commit](https://github.com/Forressveyn/transport-management-system/commit/d04b32d414f2a6157b059b6e5f27dbefc5ff9191)

## Wrong json(rows with elements) mapping google response.

Wrong json origin_addresses with destination_addresses mapping in **tms/models/tms_route.py** from 112 to 118 rows.
```
                        for row in result['rows']:
                            distance += (
                                row['elements'][0]['distance']
                                   ['value'] / 1000.0)
                            duration += (
                                row['elements'][0]['duration']
                                   ['value'] / 3600.0)
```
**elements[0]** is the same destination_addresses for each origin_addresses and it calculates a wrong distance.

fixed in [Fork commit](https://github.com/Forressveyn/transport-management-system/commit/d04b32d414f2a6157b059b6e5f27dbefc5ff9191)