### PR TITLE
[IMP] transport-management-system: Avoid error on module installation

### DIFF
--- a/tms/data/product_product_data.xml
+++ b/tms/data/product_product_data.xml
@@ -7,6 +7,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">freight</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_move" model="product.product">
         <field name="name">Move</field>
@@ -15,6 +17,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">move</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_insurance" model="product.product">
         <field name="name">Insurance</field>
@@ -23,6 +27,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">insurance</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_highway_tolls" model="product.product">
         <field name="name">Highway Tolls</field>
@@ -31,6 +37,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">tolls</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_other" model="product.product">
         <field name="name">Other</field>
@@ -39,6 +47,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">other</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_real_expense" model="product.product">
         <field name="name">Real Expense</field>
@@ -47,6 +57,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">real_expense</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_fuel" model="product.product">
         <field name="name">Fuel</field>
@@ -55,6 +67,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">fuel</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_fuel_cash" model="product.product">
         <field name="name">Fuel in Cash</field>
@@ -63,6 +77,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">fuel_cash</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_salary" model="product.product">
         <field name="name">Salary</field>
@@ -71,6 +87,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">salary</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_retention" model="product.product">
         <field name="name">Salary Retention</field>
@@ -79,6 +97,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">salary_retention</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_discount" model="product.product">
         <field name="name">Salary Discount</field>
@@ -87,6 +107,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">salary_discount</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_madeup" model="product.product">
         <field name="name">Made Up Expense</field>
@@ -95,6 +117,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">made_up_expense</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_other_income" model="product.product">
         <field name="name">Other Income</field>
@@ -103,6 +127,8 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">other_income</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_ieps" model="product.product">
         <field name="name">IEPS</field>
@@ -110,6 +136,8 @@
         <field eval="False" name="purchase_ok"/>
         <field eval="False" name="sale_ok"/>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
     <record id="product_loan" model="product.product">
         <field name="name">Loan</field>
@@ -118,5 +146,7 @@
         <field eval="False" name="sale_ok"/>
         <field name="tms_product_category">loan</field>
         <field name="categ_id" ref="product.product_category_all"/>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
     </record>
 </odoo>


### PR DESCRIPTION
The uom_id field is required in the product, is assigned with a
default method, but in some cases is not assigned (Odoo sh for example).

Its better define the field when is created the record