### PR TITLE
Remove confusing Travel field from TMS Event view

### DIFF
--- a/tms/views/tms_event_view.xml
+++ b/tms/views/tms_event_view.xml
@@ -39,7 +39,6 @@
                     <group col="4">
                         <field name="name"/>
                         <field name="date"/>
-                        <field name="travel_id"/>
                     </group>
                     <group col="4" string="GPS">
                         <field name="latitude"/>


### PR DESCRIPTION
Remove the confusing Travel field from TMS Travel history form. The travel_id is already implicitly associated when adding a line in the tree view.


![remove_travel_field_from_tms_event_view](https://user-images.githubusercontent.com/6829687/144191140-e24fe3eb-c916-4148-b82b-5d581a861096.png)


